### PR TITLE
Bring the tests up

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,3 +141,26 @@ fn main() {
         .add_system(move_bodies)
         .run();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::Body;
+
+    #[test]
+    fn one_body_stays_in_place() {
+        //let mut space = Space::default();
+        let mut app = App::new();
+
+        //app.world.spawn().insert(Body {
+        //    position: Vector::default(),
+        //    velocity: Vector::default(),
+        //    mass: Mass::from_kgs(1.0),
+        //    name: "Earth",
+        //})
+
+        //space.tick(Duration::seconds(1));
+        //assert_eq!(Vector::default(), space.bodies[0].position);
+        //assert_eq!(Vector::default(), space.bodies[0].velocity);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,6 @@ fn move_single(time: f64, force: Vector, body: &mut Body) {
     let offset_ensued_from_acceleration = acceleration * time.powf(2.) as f64 / 2.0;
 
     body.velocity = acceleration * time + body.velocity;
-    eprintln!("vel {:?}", body.velocity);
     //body.position = body.position + offset_ensued_from_acceleration + offset_ensued_from_velocity;
 }
 
@@ -105,7 +104,6 @@ fn newtownian_gravity(time: Res<Time>, mut query: Query<(&mut Body, &mut Transfo
     while let Some([(mut body1, mut transform1), (mut body2, mut transform2)]) =
         combinations.fetch_next()
     {
-        eprintln!("combination");
         let time = time.delta_seconds_f64() * 1000000.;
         let force = body1.newtonian_gravity(&*body2);
 
@@ -132,7 +130,6 @@ fn move_bodies(time: Res<Time>, mut query: Query<&mut Body>) {
         let offset_ensued_from_velocity = body.velocity * time as f64;
         body.position = body.position + offset_ensued_from_velocity;
     }
-    eprintln!("dupa {}", time);
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,7 @@ fn newtownian_gravity(time: Res<Time>, mut query: Query<(&mut Body, &mut Transfo
     while let Some([(mut body1, mut transform1), (mut body2, mut transform2)]) =
         combinations.fetch_next()
     {
+        eprintln!("combination");
         let time = time.delta_seconds_f64() * 1000000.;
         let force = body1.newtonian_gravity(&*body2);
 
@@ -219,6 +220,7 @@ mod tests {
                 mass: Mass::from_kgs(1.0),
                 name: "first".into(),
             })
+            .insert(Transform::default())
             .id();
 
         let id2 = app
@@ -233,10 +235,9 @@ mod tests {
                 mass: Mass::from_kgs(1.0),
                 name: "second".into(),
             })
+            .insert(Transform::default())
             .id();
 
-        rewind_time(&mut app.world, Duration::from_secs(1));
-        app.update();
         rewind_time(&mut app.world, Duration::from_secs(1));
         app.update();
 
@@ -244,15 +245,28 @@ mod tests {
         // This gives a gravity force equal to G. With the mass of 1, such force will give
         // the acceleration of G [m per sec per sec]. After one second such acceleration should
         // give the velocity of G.
-        assert_abs_diff_eq!(G, app.world.get::<Body>(id1).unwrap().velocity.x);
+        assert_abs_diff_eq!(
+            G,
+            app.world.get::<Body>(id1).unwrap().velocity.x,
+            epsilon = 0.01
+        );
 
         // For both bodies.
-        assert_abs_diff_eq!(-G, app.world.get::<Body>(id2).unwrap().velocity.x);
+        assert_abs_diff_eq!(
+            -G,
+            app.world.get::<Body>(id2).unwrap().velocity.x,
+            epsilon = 0.01
+        );
 
         // Distance traveled should be:
         // a * t ^ 2 / 2
         // G * 1 ^ 2 / 2
         // G / 2
-        //assert_abs_diff_eq!(G / 2.0, space.bodies[0].position.x);
+        // TODO: Check Transform component instead of Body::position!!
+        assert_abs_diff_eq!(
+            G / 2.0,
+            app.world.get::<Body>(id1).unwrap().position.x,
+            epsilon = 0.01
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,12 @@ mod tests {
     use super::Body;
     use super::*;
 
+    fn rewind_time(world: &mut World, duration: Duration) {
+        let mut time = world.resource_mut::<Time>();
+        let last_update = time.last_update().unwrap();
+        time.update_with_instant(last_update + duration);
+    }
+
     #[test]
     fn one_body_stays_in_place() {
         let mut app = App::new();
@@ -158,7 +164,7 @@ mod tests {
 
         let mut time = Time::default();
         time.update();
-        app.insert_resource(time);
+        app.world.insert_resource(time);
 
         let id = app
             .world
@@ -174,18 +180,13 @@ mod tests {
         app.update();
 
         // See if position is still the same.
-
         assert_eq!(
             Vector::default(),
             app.world.get::<Body>(id).unwrap().position
         );
 
         // Now let's see if position is still the same after another second.
-
-        let mut time = app.world.resource_mut::<Time>();
-        let last_update = time.last_update().unwrap();
-        time.update_with_instant(last_update + Duration::from_secs(1));
-
+        rewind_time(&mut app.world, Duration::from_secs(1));
         app.update();
 
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,13 @@ fn move_bodies(time: Res<Time>, mut query: Query<&mut Body>) {
     let time = time.delta_seconds_f64() * 1000000.;
     for mut body in query.iter_mut() {
         let offset_ensued_from_velocity = body.velocity * time as f64;
-        body.position = body.position + offset_ensued_from_velocity;
+        body.position = body.position
+            + offset_ensued_from_velocity
+            + Vector {
+                x: 1.,
+                y: 1.,
+                z: 1.,
+            };
     }
 }
 
@@ -144,20 +150,31 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::Body;
+    use super::*;
 
     #[test]
     fn one_body_stays_in_place() {
-        //let mut space = Space::default();
         let mut app = App::new();
 
-        //app.world.spawn().insert(Body {
-        //    position: Vector::default(),
-        //    velocity: Vector::default(),
-        //    mass: Mass::from_kgs(1.0),
-        //    name: "Earth",
-        //})
+        app.add_system(newtownian_gravity);
+        app.add_system(move_bodies);
+
+        let id = app
+            .world
+            .spawn()
+            .insert(Body {
+                position: Vector::default(),
+                velocity: Vector::default(),
+                mass: Mass::from_kgs(1.0),
+                name: "Earth".into(),
+            })
+            .id();
+
+        assert_eq!(
+            Vector::default(),
+            app.world.get::<Body>(id).unwrap().position
+        );
 
         //space.tick(Duration::seconds(1));
         //assert_eq!(Vector::default(), space.bodies[0].position);

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -141,64 +141,64 @@ impl<UserData> Space<UserData> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::units::Mass;
-    use approx::assert_abs_diff_eq;
-    use chrono::Duration;
-
-    #[test]
-    fn one_body_stays_in_place() {
-        let mut space = Space::default();
-        space.bodies.push(Body {
-            position: Vector::default(),
-            velocity: Vector::default(),
-            mass: Mass::from_kgs(1.0),
-            name: "Earth",
-        });
-        space.tick(Duration::seconds(1));
-        assert_eq!(Vector::default(), space.bodies[0].position);
-        assert_eq!(Vector::default(), space.bodies[0].velocity);
-    }
-
-    #[test]
-    fn two_bodies_fly_towards_each_other() {
-        let mut space = Space::default();
-
-        space.bodies.push(Body {
-            position: Vector::default(),
-            velocity: Vector::default(),
-            mass: Mass::from_kgs(1.0),
-            name: "first body",
-        });
-
-        space.bodies.push(Body {
-            position: Vector {
-                x: 1.0,
-                y: 0.0,
-                z: 0.0,
-            },
-            velocity: Vector::default(),
-            mass: Mass::from_kgs(1.0),
-            name: "second body",
-        });
-
-        space.tick(Duration::seconds(1));
-
-        // Distance between the two, their mass product and square of distance, all equals 1.
-        // This gives a gravity force equal to G. With the mass of 1, such force will give
-        // the acceleration of G [m per sec per sec]. After one second such acceleration should
-        // give the velocity of G.
-        assert_abs_diff_eq!(G, space.bodies[0].velocity.x);
-
-        // For both bodies.
-        assert_abs_diff_eq!(-G, space.bodies[1].velocity.x);
-
-        // Distance traveled should be:
-        // a * t ^ 2 / 2
-        // G * 1 ^ 2 / 2
-        // G / 2
-        assert_abs_diff_eq!(G / 2.0, space.bodies[0].position.x);
-    }
-}
+//#[cfg(test)]
+//mod tests {
+//    use super::*;
+//    use crate::units::Mass;
+//    use approx::assert_abs_diff_eq;
+//    use chrono::Duration;
+//
+//    #[test]
+//    fn one_body_stays_in_place() {
+//        let mut space = Space::default();
+//        space.bodies.push(Body {
+//            position: Vector::default(),
+//            velocity: Vector::default(),
+//            mass: Mass::from_kgs(1.0),
+//            name: "Earth",
+//        });
+//        space.tick(Duration::seconds(1));
+//        assert_eq!(Vector::default(), space.bodies[0].position);
+//        assert_eq!(Vector::default(), space.bodies[0].velocity);
+//    }
+//
+//    #[test]
+//    fn two_bodies_fly_towards_each_other() {
+//        let mut space = Space::default();
+//
+//        space.bodies.push(Body {
+//            position: Vector::default(),
+//            velocity: Vector::default(),
+//            mass: Mass::from_kgs(1.0),
+//            name: "first body",
+//        });
+//
+//        space.bodies.push(Body {
+//            position: Vector {
+//                x: 1.0,
+//                y: 0.0,
+//                z: 0.0,
+//            },
+//            velocity: Vector::default(),
+//            mass: Mass::from_kgs(1.0),
+//            name: "second body",
+//        });
+//
+//        space.tick(Duration::seconds(1));
+//
+//        // Distance between the two, their mass product and square of distance, all equals 1.
+//        // This gives a gravity force equal to G. With the mass of 1, such force will give
+//        // the acceleration of G [m per sec per sec]. After one second such acceleration should
+//        // give the velocity of G.
+//        assert_abs_diff_eq!(G, space.bodies[0].velocity.x);
+//
+//        // For both bodies.
+//        assert_abs_diff_eq!(-G, space.bodies[1].velocity.x);
+//
+//        // Distance traveled should be:
+//        // a * t ^ 2 / 2
+//        // G * 1 ^ 2 / 2
+//        // G / 2
+//        assert_abs_diff_eq!(G / 2.0, space.bodies[0].position.x);
+//    }
+//}

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -60,7 +60,7 @@ impl MassObject for Ship {
     }
 }
 
-const G: f64 = 6.67408e-11f64;
+pub const G: f64 = 6.67408e-11f64;
 
 #[derive(Debug)]
 pub struct Space<UserData> /* perhaps time some day... */ {


### PR DESCRIPTION
`physics` will became obsolete in favor of Bevy systems. This makes the whole thing Bevy-specific, but I think it will be easier to extract generic parts once engine migration is done.